### PR TITLE
initial textx-LS integration for types_dsl

### DIFF
--- a/01_separate_projects/types_dsl/README.md
+++ b/01_separate_projects/types_dsl/README.md
@@ -1,6 +1,6 @@
 # Example types_dsl
 
-In a virtualenv, install the package
+In a virtualenv, install the package 
 
 	virtualenv venv -p $(which python3)
 	source ./venv/bin/activate

--- a/01_separate_projects/types_dsl/requirements_dev.txt
+++ b/01_separate_projects/types_dsl/requirements_dev.txt
@@ -1,3 +1,4 @@
 pytest
 flake8
 click
+git+https://github.com/textX/textX-LS.git@danixeee/language-installation-mechanism#subdirectory=textX-LS/core

--- a/01_separate_projects/types_dsl/setup.py
+++ b/01_separate_projects/types_dsl/setup.py
@@ -9,7 +9,8 @@ setup(name='types_dsl',
       license='TODO',
       packages=find_packages(),
       package_data={'': ['*.tx']},
-      install_requires=["textx", "arpeggio", "click"],
+      install_requires=["textx", "arpeggio", "click",
+                        "textx_ls_core"],
       tests_require=[
           'pytest',
       ],
@@ -17,6 +18,9 @@ setup(name='types_dsl',
       entry_points={
           'console_scripts': [
               'types_data_flow_dslc=types_dsl.console:types_data_flow_dslc',
+          ],
+          'textxls_langs': [
+              'types_dsl = types_dsl:TypesDslLang'
           ]
       },
       )

--- a/01_separate_projects/types_dsl/types_dsl/__init__.py
+++ b/01_separate_projects/types_dsl/types_dsl/__init__.py
@@ -2,6 +2,7 @@ from textx import metamodel_from_file
 import textx.scoping
 import textx.scoping.tools as tools
 import os
+from textx_ls_core.languages import LanguageTemplate
 
 _mm_types = None
 
@@ -30,6 +31,22 @@ def _library_init():
     _mm_types.register_obj_processors({
         'Type': check_type
     })
+
+
+class TypesDslLang(LanguageTemplate):
+
+    def __init__(self):
+        super(TypesDslLang, self).__init__(auto_load_mm=False)
+
+        self._metamodel = get_metamodel_types()
+
+    @property
+    def extensions(self):
+        return ['type']
+
+    @property
+    def language_name(self):
+        return 'types_dsl'
 
 
 _library_init()

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,3 +1,4 @@
 pytest
 flake8
 click
+git+https://github.com/textX/textX-LS.git@danixeee/language-installation-mechanism#subdirectory=textX-LS/core


### PR DESCRIPTION
I made an inital adaptation for the types-language. 
 * I used the textx-LS/core library from the branch you mentioned (see requiremens_dev.txt)
 * I adapted the __init__.py file according your example.

@danixeee could you have a look? What are the next steps to make it work?

For the moment I install everything in a venv as described in the README.md in the types_dsl-subfolder:
```
	virtualenv venv -p $(which python3)
	source ./venv/bin/activate
	pip install -r requirements_dev.txt
	pip install -e .
```